### PR TITLE
Dockerfile: Upgrade spark image to v3.3.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-ARG SPARK_IMAGE=gcr.io/spark-operator/spark:v3.1.1
+ARG SPARK_IMAGE=apache/spark:v3.3.0
 
 FROM golang:1.15.2-alpine as builder
 


### PR DESCRIPTION
Upgrade spark image to v3.3.0 to reduce CVEs.

Refs arrikto/dev#2167
Refs arrikto/rok#6395

Signed-off-by: Georgios Zaravinos <gezar@arrikto.com>